### PR TITLE
added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
 verbosity=1
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True
@@ -10,3 +15,4 @@ per-file-ignores =
 
 [pylint.'MESSAGES CONTROL']
 disable=E1101
+


### PR DESCRIPTION
## Summary by Sourcery

Configure additional Nose test and coverage options in the project setup.

Build:
- Configure Nose and coverage options in setup.cfg to standardize local and CI test execution.

Tests:
- Enable Nose spec-style output with color for test runs.
- Enable coverage measurement with package-scoped reporting for the service code during tests.