### PR TITLE
completed ci build

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu:latest
     container: python:3.9-slim
   
-  services:
-    postgres: 
-      image: postgres:alpine
-      ports:
-        - 5432:5432
-      env:
-        POSTGRES_PASSWORD: pgs3cr3t
-        POSTGRES_DB: testdb
-      options: >-
-        --health-cmd ps_isready
-        --health-interval 10s
-        --health-timeout 5s
-        --health-retries 5
-    
+    services:
+      postgres: 
+        image: postgres:alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: pgs3cr3t
+          POSTGRES_DB: testdb
+        options: >-
+          --health-cmd ps_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # DevOps Capstone Project
 
+![Build Status](https://github.com/okinoleiba/devops-capstone-project/actions/workflows/ci-build.yaml/badge.svg)
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.9](https://img.shields.io/badge/Python-3.9-green.svg)](https://shields.io/)
-[![Build Status](https://github.com/okinoleiba/devops-capstone-project/actions/workflows/ci-build.yaml/badge.svg)
+
 
 
 This repository contains the starter code for the project in [**IBM-CD0285EN-SkillsNetwork DevOps Capstone Project**](https://www.coursera.org/learn/devops-capstone-project?specialization=devops-and-software-engineering) which is part of the [**IBM DevOps and Software Engineering Professional Certificate**](https://www.coursera.org/professional-certificates/devops-and-software-engineering)


### PR DESCRIPTION
## Summary by Sourcery

Set up the CI build workflow under the standard GitHub Actions location and document its status in the README.

Build:
- Move the CI build configuration into .github/workflows/ci-build.yaml and fix the workflow job configuration for the Postgres service.

Documentation:
- Add a CI build status badge to the README and clean up the previous malformed badge entry.