### PR TITLE
Merge pull request #18 from OkinoLeiba/ci-build

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -10,7 +10,7 @@ on:
 
 
 jobs:
-  build-job:
+  build:
     runs-on: ubuntu:latest
     container: python:3.9-slim
   


### PR DESCRIPTION
completed ci build

## Summary by Sourcery

CI:
- Rename the GitHub Actions job from `build-job` to `build` in the CI workflow.