### PR TITLE
fix error with nosetest

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -43,7 +43,7 @@ jobs:
           flake8 service --count --max-complexity=10 --max-line-length=127 --statistics
       
       - name: Run unit tests with Nose
-        run: nostests
+        run: nosetests
         env:
           DATABASE_URI: "postgresql://postgres:pgs3cr3t@postgres:5432/testdb"
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Correct the Nose test command in the CI workflow from a misspelled executable to the proper `nosetests` invocation.